### PR TITLE
Fix out-of-bounds array access in vertex shader

### DIFF
--- a/src/Shaders/Vertex.glsl
+++ b/src/Shaders/Vertex.glsl
@@ -51,7 +51,7 @@ void main() {
   }
 
   for (int i = 0; i < u_waveLayers_length; i++) {
-    if (u_active_colors[i + 1] == 1.) {
+    if (u_active_colors[i] == 1.) {
       WaveLayers layer = u_waveLayers[i];
 
       float noise = smoothstep(


### PR DESCRIPTION
u_active_colors was accessing [i + 1] but the active colors array is zero-indexed and matches the waveLayers array in length.

This was causing a shader cross-compile error on Blink-based browsers on Windows only